### PR TITLE
su: allow init to automatically restart daemon

### DIFF
--- a/init.superuser.rc
+++ b/init.superuser.rc
@@ -1,7 +1,6 @@
 # su daemon
 service su_daemon /system/xbin/su --daemon
     seclabel u:r:sudaemon:s0
-    oneshot
 
 on property:persist.sys.root_access=0
     stop su_daemon


### PR DESCRIPTION
When "oneshot" is used, init will not automatically restart the
daemon. This prevents root access when the su daemon dies or is
killed.

Example of issue:
	shell@mako:/ $ su
	root@mako:/ # killall su
	Terminated
	143|shell@mako:/ $ su
	255|shell@mako:/ $

From logcat:
	D/su      ( 5542): su invoked.
	D/su      ( 5542): starting daemon client 2000 2000
	E/su      ( 5542): connect failed with 111: Connection refused

Change-Id: I15636980f1d971f7c1b2be60c650887015a7b65a